### PR TITLE
Make middleware function public

### DIFF
--- a/lib/cimpler.js
+++ b/lib/cimpler.js
@@ -73,6 +73,23 @@ function Cimpler(config) {
       }, repoMatcher);
    };
 
+   /**
+    * Register the passed function as a connect.js middleware under the given
+    * route. The two arguments will be passed directly to connect.use().
+    */
+   this.registerMiddleware = function(route, inMiddleware){
+      if (!connect) {
+         connect = Connect()
+            .use(Connect.responseTime())
+            .use(Connect.bodyParser())
+            .use(Connect.query());
+
+         connectServer = connect.listen(config.httpPort);
+      }
+
+      connect.use(route, inMiddleware);
+   };
+
    this.registerPlugin = function(plugin, configs) {
       var cimpler = this;
       if (!(configs instanceof Array)) {
@@ -80,7 +97,7 @@ function Cimpler(config) {
       }
 
       configs.forEach(function(config) {
-         plugin.init(config, cimpler, registerMiddleware);
+         plugin.init(config, cimpler);
          cimpler.plugins.push(plugin);
       });
    };
@@ -132,20 +149,6 @@ function Cimpler(config) {
       var plugin = require(pluginPath);
       cimpler.registerPlugin(plugin, pluginConfig);
    });
-
-
-   function registerMiddleware(route, inMiddleware){
-      if (!connect) {
-         connect = Connect()
-            .use(Connect.responseTime())
-            .use(Connect.bodyParser())
-            .use(Connect.query());
-
-         connectServer = connect.listen(config.httpPort);
-      }
-
-      connect.use(route, inMiddleware);
-   }
 }
 util.inherits(Cimpler, events.EventEmitter);
 

--- a/plugins/build-status.js
+++ b/plugins/build-status.js
@@ -1,7 +1,7 @@
 var http = require('http');
 
-exports.init = function(config, cimpler, middleware) {
-   middleware('/builds/status', function(req, res, next) {
+exports.init = function(config, cimpler) {
+   cimpler.registerMiddleware('/builds/status', function(req, res, next) {
       res.end(JSON.stringify(cimpler.builds(true)));
    });
 };

--- a/plugins/cli.js
+++ b/plugins/cli.js
@@ -5,14 +5,14 @@ var util       = require('util'),
     ];
 
 
-exports.init = function(config, cimpler, middleware) {
+exports.init = function(config, cimpler) {
 
    /**
     * Listen for incoming data via HTTP.
     *
     * This expects JSON formatted POSTs at url: /build
     */
-   middleware("/build", function (req, res, next) {
+   cimpler.registerMiddleware("/build", function (req, res, next) {
       // We only care about POSTs to "/build" 
       if (req.method !== 'POST' || !req.url.match(/^\/($|\?)/)) {
          return next();

--- a/plugins/github.js
+++ b/plugins/github.js
@@ -8,11 +8,11 @@ var util       = require('util'),
     ];
 
 
-exports.init = function(config, cimpler, middleware) {
+exports.init = function(config, cimpler) {
    /**
-    * Listen for post-recieve hooks
+    * Listen for post-receive hooks
     */
-   middleware('/github', function(req, res, next) {
+   cimpler.registerMiddleware('/github', function(req, res, next) {
       // We only care about POSTs to "/github"
       if (req.method !== 'POST' || req.url !== '/') {
          return next();


### PR DESCRIPTION
Instead of passing in a function to plugin.init(),
just move the middleware registering function to a public API.

Not sure why I didn't do that in the first place, it's a lot more
consistent with the rest of the functionality (addBuild,
consumeBuild, ...).
