### PR TITLE
commit-status: only one status when fast-failing

### DIFF
--- a/plugins/github-commit-status.js
+++ b/plugins/github-commit-status.js
@@ -9,7 +9,9 @@ exports.init = function(config, cimpler) {
    GitHub.authenticate(config.auth);
 
    cimpler.on('buildStarted', function(build) {
-      reportBuildStatus(build, 'pending', 'Build Started');
+      if (!build.error) {
+         reportBuildStatus(build, 'pending', 'Build Started');
+      }
    });
 
    cimpler.on('buildFinished', function(build) {


### PR DESCRIPTION
Only report a single "failed" status when a build is "finished" before it is
"started"

Plugins have the option of calling finish() on a build before calling start()
which causes the system to implicitly call start(). The git-build plugin does
this for merge-failures (start isn't usually called till the merge is
successful).

The problem is that "buildStarted" and "buildFinished" are called right after
eachother, causing the github-commit-status plugin to fire off two commit
statuses (one 'started' and one 'merge failed') at almsot exactly the same
time. Github uses whichever status was recieved most recently, so it's kind of
a race condition and half the time, the 'started' message arrives after the
'failed' message, causing a forever 'in progress' state for that commit / pull.

This change simply doesn't send the 'started' status to github during the
'buildStarted' even when a build has already been marked as failed.
