### PR TITLE
Log tailing: prevent timing out on slow output.

### DIFF
--- a/lib/http-trigger.js
+++ b/lib/http-trigger.js
@@ -1,6 +1,7 @@
 var http     = require('http'),
     fs       = require('fs'),
     url      = require('url'),
+    connectionTimeout = 30*60*1000, // 30 min
     defaulthttpPort = 25750;
 
 /**
@@ -31,6 +32,9 @@ exports.injectBuild = function injectBuild(build, options, callback) {
    };
 
    var req = http.request(reqOptions, onResponse);
+   // To support both <=0.8 and >=0.10
+   var connection = req.connection || req;
+   connection.setTimeout(connectionTimeout);
 
    req.on('error', function(err) {
       console.log("Couldn't connect to cimpler server");

--- a/plugins/cli.js
+++ b/plugins/cli.js
@@ -1,5 +1,6 @@
 var util       = require('util'),
     _          = require('underscore'),
+    connectionTimeout = 30*60*1000, // 30 min
     allowedIps = [
        '127.0.0.1'
     ];
@@ -42,6 +43,10 @@ exports.init = function(config, cimpler) {
 
       // Schedule the logs to be piped once the build starts
       if (build._control.tail_log) {
+         // To support both <=0.8 and >=0.10
+         var connection = res.connection || res;
+         connection.setTimeout(connectionTimeout);
+
          uponStarting(build, function() {
             var sanitizedBuild = _.omit(build, '_control');
             res.write(JSON.stringify(sanitizedBuild) + "\n");


### PR DESCRIPTION
In earlier versions, there was undocumented access to the internal connection
object, which exposes it's setTimeout() function.

Tested, works fine with a command like "echo 20min; sleep 1200; echo done"
