### PR TITLE
build._control: ensure all builds have ._control

### DIFF
--- a/lib/cimpler.js
+++ b/lib/cimpler.js
@@ -22,6 +22,12 @@ function Cimpler(config) {
    config = config || {};
 
    this.addBuild = function(build) {
+      build.status = build.status || 'pending';
+
+      // The _control property allows plugins to pass around data
+      // without clobbering real build properties.
+      build._control = build._control || {};
+
       var existingBuilds = builds.items();
       for(var i=0; i < existingBuilds.length; i++) {
          if (existingBuilds[i].branch == build.branch &&
@@ -30,12 +36,6 @@ function Cimpler(config) {
              return;
          }
       }
-
-      build.status = build.status || 'pending';
-
-      // The _control property allows plugins to pass around data
-      // without clobbering real build properties.
-      build._control = build._control || {};
 
       this.emit('buildAdded', build);
       builds.push(build);

--- a/test/cimpler.test.js
+++ b/test/cimpler.test.js
@@ -227,6 +227,14 @@ describe("Cimpler", function() {
 
          var builds = [build,build,build,build];
 
+         // This ensures the builds get the various properties added to them.
+         build = {
+            repo:    "blah",
+            branch:  "A",
+            _control: {},
+            status:  "pending"
+         };
+
          // expected.length == 2 because the first one is pop()ed immediately
          // and thus can't be replaced.
          passBuildsThrough(builds, [build, build], done);


### PR DESCRIPTION
If a build was added to the queue, then re-added we swap the old build
with the new one but didn't bother giving it the default properties
(_control and status).

This was causing failures down the line when build._control was
referenced. This change ensures that all builds have _control and status
and updates the tests to ensure that.
