### PR TITLE
git-build: run 'git submodule sync' after merge

### DIFF
--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -69,6 +69,7 @@ function buildConsumer(config, cimpler, repoPath) {
             "git clean -ffd && " +
             "git checkout "+build.commit+" && " +
             "git merge origin/master && " +
+            "git submodule sync && " +
             "git submodule update --init --recursive ) 2>&1";
 
          exec(commands, function(err, stdout) {


### PR DESCRIPTION
So that changes in submodule urls are propagated to each submodule
repo.
