### PR TITLE
build-logs: delay creation till we have a commit

### DIFF
--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -39,15 +39,18 @@ function buildConsumer(config, cimpler, repoPath) {
 
       startFetch();
 
+      // This needs to be delayed until we have a commit hash
+      function writeLogHeader() {
+         logFile().write( 
+            "----------------------------------------------\n" +
+            " Cimpler build started at: " + Date() + "\n" +
+            "----------------------------------------------\n");
+      }
+
       function startFetch() {
          var commands = '(cd "' + repoPath + '" && ' +
             "git fetch --quiet && " +
             "git rev-parse origin/" + build.branch + ") 2>&1";
-
-         logFile().write( 
-         "----------------------------------------------\n" +
-         " Cimpler build started at: " + Date() + "\n" +
-         "----------------------------------------------\n");
 
          exec(commands, function(err, stdout) {
             if (err) {
@@ -56,12 +59,14 @@ function buildConsumer(config, cimpler, repoPath) {
                build.error = failed;
                stdout += "\n\n" + failed;
                logger.warn(id(build) + " -- " + failed);
+               writeLogHeader()
                logFile().write(stdout);
                finishedBuild();
             } else {
                if (!build.commit) {
                   build.commit = stdout.trim();
                }
+               writeLogHeader();
                startMerge();
             }
          });


### PR DESCRIPTION
If we delay log creation until we have a commit hash then it will be
included in the log filename (instead of "unknown")
