### PR TITLE
Build logs: remove tail options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ But, cimpler does provide a local-repo post-receive hook and a nice CLI:
     Options:
       --command, -c  Custom shell command to execute for this build
                      instead of the one from the config file
-      --tail         [ or --no-tail ] Blocks until the build is started
-                     and tails the log when used with the "build"
-                     command.  [boolean] [default: true]
       --branch, -b   Name of the branch to build (defaults to current)
       --verbose, -v  Produce more output for the status command.
                      Includes details for each build.

--- a/bin/cimpler
+++ b/bin/cimpler
@@ -15,11 +15,6 @@ args           = require('optimist')
       alias: 'c',
       describe: 'Custom shell command to execute for this build instead of the one from the config file'
    })
-   .options('tail', {
-      boolean: true,
-      default: true,
-      describe: '[ or --no-tail ] Blocks until the build is started and tails the log when used with the "build" command.'
-   })
    .options('branch', {
       alias: 'b',
       describe: 'Name of the branch to build (defaults to current)'
@@ -51,12 +46,6 @@ switch (command) {
       }
 
       function getBranch() {
-         if (args.block) {
-            console.log("Blocking until the build has been started... Ctrl-C exits, but won't stop the build")
-         }
-         var options = {
-            tail: args.tail
-         };
          if (args.branch) {
             triggerBuild(args.branch);
          } else {
@@ -65,7 +54,10 @@ switch (command) {
 
          function triggerBuild(branch) {
             build.branch = branch;
-            options.httpPort = args.port;
+            var options = {
+               httpPort: args.port
+            };
+
             httpTrigger.injectBuild(build, options);
          }
       }

--- a/lib/http-trigger.js
+++ b/lib/http-trigger.js
@@ -13,18 +13,11 @@ exports.injectBuild = function injectBuild(build, options, callback) {
                || loadPortFromConfig()
                || defaulthttpPort;
 
-   options = options || {};
-   var urlParams = {};
-   if (options.tail) {
-      urlParams.tail_log = 'true';
-      process.stdout.write("Ctrl-C will not stop the build, only the display.\n\n");
-   }
-
    process.stdout.write("Adding build of " + build.branch + " to the queue ... ");
 
    var reqOptions = {
       port: httpPort,
-      path: '/build' + url.format({query:urlParams}),
+      path: '/build',
       method: 'POST',
       headers: {
          'Content-Type' : 'application/json'

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -165,12 +165,6 @@ function buildConsumer(config, cimpler, repoPath) {
           */
          proc.stdout.pipe(logFile(), {end:false});
          proc.stderr.pipe(logFile(), {end:false});
-         if (build._control.tail_log) {
-            build._control.logs = {
-               stdout : proc.stdout,
-               stderr : proc.stderr
-            };
-         }
 
          // Fire the started event now that our build has a log.
          started();

--- a/test/cli-plugin.test.js
+++ b/test/cli-plugin.test.js
@@ -46,59 +46,6 @@ describe("CLI plugin", function() {
       req.end(JSON.stringify(build));
    });
 
-   it("should accept builds via HTTP and block", function(done) {
-      var cb = 0,
-      logStream = new stream.Stream(),
-      cimpler = createCimpler();
-
-      var build = {
-         repo:       'http',
-         branch:     'test-branch',
-         sha:        '12345678',
-         status:     'pending'
-      };
-
-      cimpler.consumeBuild(function(inBuild, started) {
-         logStream.readable = true;
-         setTimeout(function() {
-            inBuild.started = true;
-            inBuild._control.logs = {
-               stdout: logStream
-            }
-            started();
-            logStream.emit("data", "OUTPUT");
-            logStream.emit("end");
-         }, 50);
-      });
-
-      var options = {
-         port: httpPort,
-         path: '/build?tail_log=true',
-         method: 'POST',
-         headers: {
-            'Content-Type' : 'application/json'
-         }
-      };
-
-      var req = http.request(options, function(res) {
-         var body = '';
-         res.setEncoding('utf8');
-         res.on('data', function(chunk) {
-            body += chunk;
-         });
-
-         res.on('end', function(err) {
-            build.started = true;
-            assert.equal(body, "Added ... Build Started\n\nOUTPUT");
-            cimpler.shutdown();
-            if (err) assert.fail(err);
-            done();
-         });
-      });
-
-      req.end(JSON.stringify(build));
-   });
-
    function createCimpler() {
       return new Cimpler({
          plugins: {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -46,7 +46,6 @@ describe("CLI build command", function() {
          // So the next assertion will succeed
          expectedBuild.branch = 'test-branch';
          expectedBuild.buildCommand = 'blah';
-         expectedBuild._control.tail_log = true;
 
          finished();
          check();
@@ -54,9 +53,9 @@ describe("CLI build command", function() {
 
       exec(bin, function(stdout) { }, /* expect failure = */ true);
 
-      exec(bin + " build --no-tail", function(stdout) {
+      exec(bin + " build", function(stdout) {
          check();
-         exec(bin + " build --tail --branch=test-branch --command='blah'", function(stdout) {
+         exec(bin + " build --branch=test-branch --command='blah'", function(stdout) {
             check();
          });
       });


### PR DESCRIPTION
It wasn't really used, always ignored and was usurping the log stream
from being piped to the file if you let it tail to the screen.
