### PR TITLE
Canonicalize github urls

### DIFF
--- a/bin/cimpler
+++ b/bin/cimpler
@@ -45,6 +45,9 @@ switch (command) {
          build.buildCommand = args.command;
       }
       git.remote(function(remote, repoPath) {
+         if (remote && remote.indexOf('github.com') !== -1) {
+            remote = Git.canonicalizeGithubUrl(remote);
+         }
          build.repo = remote || repoPath;
          getBranch();
       });

--- a/lib/git.js
+++ b/lib/git.js
@@ -46,6 +46,11 @@ Git.prototype.currentBranch = function(cb) {
    });
 };
 
+Git.canonicalizeGithubUrl = function(remote) {
+   var repo = Git.parseGithubUrl(remote);
+   return ["github.com", repo.user, repo.name].join('/');
+}
+
 /**
  * Returns {user: 'person', repo: 'someproject'} given a url like:
  * http://github.com/person/someproject

--- a/lib/git.js
+++ b/lib/git.js
@@ -46,6 +46,19 @@ Git.prototype.currentBranch = function(cb) {
    });
 };
 
+/**
+ * Returns {user: 'person', repo: 'someproject'} given a url like:
+ * http://github.com/person/someproject
+ */
+Git.parseGithubUrl = function(remote) {
+   var matches = remote.match(/([^:\/]+)\/([^\/]+?)(\.git|$)/);
+   return {
+      user: matches[1],
+      name: matches[2]
+   };
+}
+
+
 Git.prototype._exec = function exec(cmd, callback) {
    childProcess.exec(cmd, this._execOptions, function(err, stdout, stderr) {
       if (err) {

--- a/plugins/github-commit-status.js
+++ b/plugins/github-commit-status.js
@@ -1,4 +1,5 @@
 var util   = require('util'),
+Git        = require('../lib/git'),
 GitHubApi  = require('github');
 
 exports.init = function(config, cimpler) {
@@ -24,7 +25,7 @@ exports.init = function(config, cimpler) {
          return;
       }
 
-      var repo = extractRepoFromURL(build.repo);
+      var repo = Git.parseGithubUrl(build.repo);
 
       // If we don't know the commit SHA, we can't report the status
       if (!build.commit) return;
@@ -40,14 +41,6 @@ exports.init = function(config, cimpler) {
       GitHub.repos.createStatus(commitStatus);
    }
 };
-
-function extractRepoFromURL(url) {
-   var matches = url.match(/([^:\/]+)\/([^\/]+?)(\.git|$)/);
-   return {
-      user: matches[1],
-      name: matches[2]
-   };
-}
 
 function getGithubApi(config) {
    var githubApi = new GitHubApi({

--- a/plugins/github.js
+++ b/plugins/github.js
@@ -43,7 +43,7 @@ function extractBuildInfo(requestBody) {
 
    // Build info structure
    return {
-     repo   : info.repository.url,
+     repo   : "github.com" + '/' + info.repository.full_name,
      commit : info.after,
      branch : branch,
      status : 'pending'

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -20,7 +20,7 @@ options = {
 testBranchName = "branch-name-with/slashes.and.dots",
 postBuild = {
    ref:"refs/heads/" + testBranchName,
-   repository:{url:"http"},
+   repository:{full_name:"user/repo"},
    after: commit
 };
 
@@ -60,7 +60,7 @@ describe("Github plugin", function() {
 
          var sanitizedBuild = _.pick(build, 'repo', 'commit', 'branch', 'status')
          assert.deepEqual(sanitizedBuild, {
-            repo:    'http',
+            repo:    'github.com/user/repo',
             commit:   commit,
             branch:  testBranchName,
             status:  'pending'


### PR DESCRIPTION
Since we don't actually use the url for anything other than identifing
builds and parsing for user/repo to report commit status to github, we
might as well canonicalize them.

Previously several builds on the same branch could end up in the queue
because they were added under synonymous github remote urls (ssh vs
git vs https).
