### PR TITLE
Allow cimpler to connect to a remote cimpler server

### DIFF
--- a/bin/cimpler
+++ b/bin/cimpler
@@ -34,7 +34,7 @@ args           = require('optimist')
 
 var command = args._[0];
 
-connOptions = {
+connectionOptions = {
    httpHost: args.host,
    httpPort: args.port
 };
@@ -63,13 +63,13 @@ switch (command) {
 
          function triggerBuild(branch) {
             build.branch = branch;
-            httpTrigger.injectBuild(build, connOptions);
+            httpTrigger.injectBuild(build, connectionOptions);
          }
       }
       break;
 
    case 'status':
-      httpTrigger.getStatus(connOptions, function(err, builds) {
+      httpTrigger.getStatus(connectionOptions, function(err, builds) {
          if (args.verbose) {
             console.dir([].concat(builds.building, builds.queued));
             return;

--- a/bin/cimpler
+++ b/bin/cimpler
@@ -23,12 +23,21 @@ args           = require('optimist')
       alias: 'v',
       describe: 'Produce more output for the status command. Includes details for each build.'
    })
+   .options('host', {
+      alias: 'h',
+      describe: 'HTTP host of the cimpler server (defaults to the value in config.js)'
+   })
    .options('port', {
       alias: 'p',
       describe: 'HTTP port of the cimpler server (defaults to the value in config.js)'
    }).argv;
 
 var command = args._[0];
+
+connOptions = {
+   httpHost: args.host,
+   httpPort: args.port
+};
 
 switch (command) {
    case 'build':
@@ -54,17 +63,13 @@ switch (command) {
 
          function triggerBuild(branch) {
             build.branch = branch;
-            var options = {
-               httpPort: args.port
-            };
-
-            httpTrigger.injectBuild(build, options);
+            httpTrigger.injectBuild(build, connOptions);
          }
       }
       break;
 
    case 'status':
-      httpTrigger.getStatus(args.port, function(err, builds) {
+      httpTrigger.getStatus(connOptions, function(err, builds) {
          if (args.verbose) {
             console.dir([].concat(builds.building, builds.queued));
             return;

--- a/config.sample.js
+++ b/config.sample.js
@@ -7,6 +7,7 @@ module.exports = {
     *
     * All interaction is done via http.
     */
+   httpHost: 'example.com',
    httpPort: 25751,
 
    /**

--- a/lib/http-trigger.js
+++ b/lib/http-trigger.js
@@ -9,13 +9,16 @@ var http     = require('http'),
  * the same http port as the CLI plugin.
  */
 exports.injectBuild = function injectBuild(build, options, callback) {
-   httpPort = (options && options.httpPort)
+   var httpHost = (options && options.httpHost)
+               || loadHostFromConfig();
+   var httpPort = (options && options.httpPort)
                || loadPortFromConfig()
                || defaulthttpPort;
 
    process.stdout.write("Adding build of " + build.branch + " to the queue ... ");
 
    var reqOptions = {
+      host: httpHost,
       port: httpPort,
       path: '/build',
       method: 'POST',
@@ -59,10 +62,15 @@ exports.injectBuild = function injectBuild(build, options, callback) {
    }
 }
 
-exports.getStatus = function(httpPort, callback) {
-   httpPort = httpPort || loadPortFromConfig() || defaulthttpPort;
+exports.getStatus = function(options, callback) {
+   var httpHost = (options && options.httpHost)
+               || loadHostFromConfig();
+   var httpPort = (options && options.httpPort)
+               || loadPortFromConfig()
+               || defaulthttpPort;
 
    var options = {
+      host: httpHost,
       port: httpPort,
       path: '/builds/status'
    };
@@ -95,6 +103,11 @@ exports.getStatus = function(httpPort, callback) {
          process.exit(1);
       });
    }
+}
+
+function loadHostFromConfig() {
+   var config = loadConfig(__dirname + '/../config.js');
+   return config && config.httpHost;
 }
 
 function loadPortFromConfig() {

--- a/lib/http-trigger.js
+++ b/lib/http-trigger.js
@@ -2,6 +2,7 @@ var http     = require('http'),
     fs       = require('fs'),
     url      = require('url'),
     connectionTimeout = 30*60*1000, // 30 min
+    defaulthttpHost = 'localhost',
     defaulthttpPort = 25750;
 
 /**
@@ -10,7 +11,8 @@ var http     = require('http'),
  */
 exports.injectBuild = function injectBuild(build, options, callback) {
    var httpHost = (options && options.httpHost)
-               || loadHostFromConfig();
+               || loadHostFromConfig()
+               || defaulthttpHost;
    var httpPort = (options && options.httpPort)
                || loadPortFromConfig()
                || defaulthttpPort;
@@ -64,7 +66,8 @@ exports.injectBuild = function injectBuild(build, options, callback) {
 
 exports.getStatus = function(options, callback) {
    var httpHost = (options && options.httpHost)
-               || loadHostFromConfig();
+               || loadHostFromConfig()
+               || defaulthttpHost;
    var httpPort = (options && options.httpPort)
                || loadPortFromConfig()
                || defaulthttpPort;

--- a/plugins/cli.js
+++ b/plugins/cli.js
@@ -20,7 +20,7 @@ exports.init = function(config, cimpler) {
 
       if (allowedIps.indexOf(req.connection.address().address) < 0) {
          util.error("Connection denied from: " +
-            JSON.stringify(connection.address()));
+            JSON.stringify(req.connection.address()));
          return next({status: 403});
       }
 


### PR DESCRIPTION
The host was defaulting to `localhost`. This allows the host to be set
via the config file or a CLI param.