### PR TITLE
CLI: Remove IP whitelist

### DIFF
--- a/plugins/cli.js
+++ b/plugins/cli.js
@@ -1,8 +1,5 @@
 var util       = require('util'),
-    _          = require('underscore'),
-    allowedIps = [
-       '127.0.0.1'
-    ];
+    _          = require('underscore');
 
 
 exports.init = function(config, cimpler) {
@@ -16,12 +13,6 @@ exports.init = function(config, cimpler) {
       // We only care about POSTs to "/build" 
       if (req.method !== 'POST' || !req.url.match(/^\/($|\?)/)) {
          return next();
-      }
-
-      if (allowedIps.indexOf(req.connection.address().address) < 0) {
-         util.error("Connection denied from: " +
-            JSON.stringify(req.connection.address()));
-         return next({status: 403});
       }
 
       var build = req.body;


### PR DESCRIPTION
Although IP whitelisting is a great feature, it's easier to implement at
the network level by opening and closing the entire port that cimpler is
listening on instead. Also, it was checking the current server's IP
address rather than the remote address so you'd have to add the current
server's IP to the list which allows access to from everywhere.

This just removes the whitelist entirely to simplify configuration.