### PR TITLE
Git build: Fix BUILD_COMMIT environment variable

### DIFF
--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -74,7 +74,10 @@ function buildConsumer(config, cimpler, repoPath) {
                finishedBuild();
             } else {
                if (!build.commit) {
+                  // Update the build commit and the environment variable if
+                  // we didn't know what the build commit was previously.
                   build.commit = stdout.trim();
+                  execOptions.env.BUILD_COMMIT = build.commit;
                }
                writeLogHeader();
                startMerge();

--- a/test/git-build.test.js
+++ b/test/git-build.test.js
@@ -15,6 +15,9 @@ var testBranch = "aa6b0aa64229caee1b07500334a64de9e1ffcddd",
     masterParent = "aac5cd96ddd3173678e3666d677699ea6adce875",
     hotfixTestBranch = "97d2ad995a7ea62bc425b3d75c7629e0b836a456";
 
+// Command to test that the BUILD_COMMIT environment variable is correct.
+var buildCommitTest = "[ \"$BUILD_COMMIT\" = '" + testBranch + "' ]";
+
 describe("git-build plugin", function() {
    var testRepoDirs = [tempDir(), tempDir()];
 
@@ -28,8 +31,9 @@ describe("git-build plugin", function() {
                mergeBranchRegexes: [
                   [/^hotfix-/, 'test-branch']
                ],
-               // Pass if test_branch is the build branch
-               cmd: "[ \"$BUILD_BRANCH\" = 'test-branch' ]",
+               // Pass if test_branch is the build branch and BUILD_COMMIT
+               // is correct.
+               cmd: "[ \"$BUILD_BRANCH\" = 'test-branch' ] && " + buildCommitTest,
                logs: {
                   path: buildLogsPath,
                   url:  buildLogsUrl


### PR DESCRIPTION
The `BUILD_COMMIT` environment variable wasn't set when manually
queueing a build via `cimpler build` so build scripts couldn't reliably
use it.

This updates the test so it was failing until I made the fix to set the
variable properly.