### PR TITLE
Modify repo regex to accept dots preceding .git

### DIFF
--- a/plugins/github-commit-status.js
+++ b/plugins/github-commit-status.js
@@ -41,7 +41,7 @@ exports.init = function(config, cimpler) {
 };
 
 function extractRepoFromURL(url) {
-   var matches = url.match(/([^:\/]+)\/([^\/.]+)(\.git|$)/);
+   var matches = url.match(/([^:\/]+)\/([^\/]+?)(\.git|$)/);
    return {
       user: matches[1],
       name: matches[2]


### PR DESCRIPTION
The current repo regex won't handle a repo path that has a period before
the .git. For example if you have your repo as cimpler.js.git it would
not be parsed correctly until this change.

This regex was a bit funky since the browser, and node seem to disagree
on how to interpret this regex. This regex works as we intend it to on
node though.