### PR TITLE
Cimpler: Allow filtering builds using a provided function

### DIFF
--- a/lib/cimpler.js
+++ b/lib/cimpler.js
@@ -47,10 +47,18 @@ function Cimpler(config) {
       }
    };
 
-   this.consumeBuild = function(callback, repoRegex) {
-      var repoMatcher = repoRegex && function(build) {
-         return repoRegex.test(build.repo);
+   this.consumeBuild = function(callback, buildFilter) {
+      var filter;
+      if (buildFilter instanceof RegExp) {
+         filter = function(build) {
+            return buildFilter.test(build.repo);
+         }
+      } else if (_.isFunction(buildFilter)) {
+         filter = function(build) {
+            return buildFilter(build);
+         }
       }
+
 
       var consumer = {
          build: null
@@ -76,7 +84,7 @@ function Cimpler(config) {
                done();
             });
          }
-      }, repoMatcher);
+      }, filter);
    };
 
    /**

--- a/lib/cimpler.js
+++ b/lib/cimpler.js
@@ -54,9 +54,7 @@ function Cimpler(config) {
             return buildFilter.test(build.repo);
          }
       } else if (_.isFunction(buildFilter)) {
-         filter = function(build) {
-            return buildFilter(build);
-         }
+         filter = buildFilter
       }
 
 

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -10,7 +10,7 @@ exports.init = function(config, cimpler) {
    paths = Array.isArray(paths) ? paths : [paths]
    paths.forEach(function(repoPath) {
       var consumer = buildConsumer(config, cimpler, repoPath);
-      cimpler.consumeBuild(consumer, config.repoRegex);
+      cimpler.consumeBuild(consumer, config.repoRegex || config.buildFilter);
    });
 
    cimpler.on('buildAborted', function(build) {

--- a/test/cimpler.test.js
+++ b/test/cimpler.test.js
@@ -203,6 +203,36 @@ describe("Cimpler", function() {
             };
          }
       });
+
+      it("should allow filtering with a function that is passed the build", function(done) {
+         var cimpler = new Cimpler();
+         var check = expect(1, done);
+
+         cimpler.consumeBuild(buildAsserter('A', 'master'), function(build) {
+            return build.repo == 'A' && build.branch == 'master';
+         });
+
+         cimpler.addBuild(build('A', 'master'));
+         cimpler.addBuild(build('A', 'test'));
+         cimpler.addBuild(build('B', 'master'));
+         cimpler.addBuild(build('B', 'test'));
+
+         function buildAsserter(expectedRepo, expectedBranch) {
+            return function(inBuild, started, finished) {
+               assert.equal(inBuild.repo, expectedRepo);
+               assert.equal(inBuild.branch, expectedBranch);
+               finished();
+               check();
+            };
+         }
+
+         function build(repo, branch) {
+            return {
+               repo: repo,
+               branch: branch
+            };
+         }
+      });
    });
 
    describe(".addBuild()", function() {


### PR DESCRIPTION
Previously `consumeBuild` only filtered based on a provided regular expression that would match against the repo name for individual builds. This pull adds the ability to define a function that is passed the build object and filter based on a returned boolean value.