### PR TITLE
Cimpler: Add ability to define shouldMergeBuilds function in config

### DIFF
--- a/lib/cimpler.js
+++ b/lib/cimpler.js
@@ -29,8 +29,11 @@ function Cimpler(config) {
       build._control = build._control || {};
 
       var existingBuilds = builds.items();
+
+      var shouldMergeBuilds = typeof config.shouldMergeBuilds !== 'undefined' ?
+       config.shouldMergeBuilds : buildEquals;
       for (var i = 0; i < existingBuilds.length; i++) {
-         if (buildEquals(existingBuilds[i], build)) {
+         if (shouldMergeBuilds(existingBuilds[i], build)) {
             existingBuilds[i] = build;
             return;
          }

--- a/test/cimpler.test.js
+++ b/test/cimpler.test.js
@@ -360,6 +360,44 @@ describe("Cimpler", function() {
          cimpler.addBuild(buildA2);
       });
 
+      it("should merge builds depending on return value of config supplied shouldMergeBuilds function", function(done) {
+         var builds = [
+            { repo: 'A' },
+            { repo: 'A' },
+            { repo: 'B' },
+            { repo: 'B' },
+            { repo: 'C' },
+            { repo: 'C' },
+         ];
+
+         var falseConfig = {
+            shouldMergeBuilds: function(runningBuild, newBuild) {
+               return false;
+            }
+         };
+
+         var cimpler = new Cimpler(falseConfig);
+
+         builds.forEach(function(build) {
+            cimpler.addBuild(build);
+         });
+         assert.equal(builds.length, cimpler.builds()['queued'].length);
+
+         var trueConfig = {
+            shouldMergeBuilds: function(runningBuild, newBuild) {
+               return true;
+            }
+         };
+         cimpler = new Cimpler(trueConfig);
+
+         builds.forEach(function(build) {
+            cimpler.addBuild(build);
+         });
+         assert.equal(1, cimpler.builds()['queued'].length);
+
+         done();
+      });
+
       function passBuildsThrough(inBuilds, expectedOutBuilds, done) {
          var outBuilds = [],
          cimpler = new Cimpler();


### PR DESCRIPTION
The current behavior when determining if builds should be 'merged' is to compare the repo and branch of the two builds. If they're the same then we don't add the build to the queue but instead we replace the old build with the new one effectively 'merging' the two build requests. This works fine but there might be cases where we want to be able to build the same branch but at different points in the branch's commit history. 

This pull adds the ability to define a `shouldMergeBuilds` function in the config.js file that will be used to determine if two builds should be merged. Doing this allows users to more finely control when builds should be merged e.g. only 'merge' build requests when the _commits_ are the same in addition to the repo and branch.

CC @danielbeardsley 