### PR TITLE
Github plugin: support branches with forward slashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "4.5"
+  - 6
+  - 8

--- a/plugins/github.js
+++ b/plugins/github.js
@@ -27,13 +27,13 @@ function extractBuildInfo(requestBody) {
    var info = JSON.parse(requestBody.payload);
 
    // ref: "refs/heads/some-long-branch-name/maybe-even-slashes"
-   var matches = info.ref.match(/^(refs\/[^\/]+)\/(.*$)/);
+   const matches = info.ref.match(/^(refs\/[^\/]+)\/(.*$)/);
    if (!matches) {
       return null;
    }
 
-   var headType = matches[1];
-   var branch = matches[2];
+   const headType = matches[1];
+   const branch = matches[2];
 
    // Filter out notifications about anything but branches (i.e. tags)
    if (headType !== 'refs/heads') {

--- a/plugins/github.js
+++ b/plugins/github.js
@@ -26,13 +26,20 @@ exports.init = function(config, cimpler) {
 function extractBuildInfo(requestBody) {
    var info = JSON.parse(requestBody.payload);
 
-   // Filter out notifications about annotated tags
-   if (info.ref.indexOf('refs/tags/') == 0) {
+   // ref: "refs/heads/some-long-branch-name/maybe-even-slashes"
+   var matches = info.ref.match(/^(refs\/[^\/]+)\/(.*$)/);
+   if (!matches) {
       return null;
    }
 
-   // ref: "refs/heads/master"
-   var branch = info.ref.split('/').pop();
+   var headType = matches[1];
+   var branch = matches[2];
+
+   // Filter out notifications about anything but branches (i.e. tags)
+   if (headType !== 'refs/heads') {
+      return null;
+   }
+
 
    // Build info structure
    return {

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -17,8 +17,9 @@ options = {
       "Content-Type": "application/x-www-form-urlencoded"
    }
 },
+testBranchName = "branch-name-with/slashes.and.dots",
 postBuild = {
-   ref:"b/master",
+   ref:"refs/heads/" + testBranchName,
    repository:{url:"http"},
    after: commit
 };
@@ -61,7 +62,7 @@ describe("Github plugin", function() {
          assert.deepEqual(sanitizedBuild, {
             repo:    'http',
             commit:   commit,
-            branch:  'master',
+            branch:  testBranchName,
             status:  'pending'
          });
          finished();


### PR DESCRIPTION
The ref property contains a branch name and branch names can
contain forward slashes. Extract everything after the first two
slashes and use that as the prefix, while everything after is
treated as the branch name.