### PR TITLE
KillChildrenOnExit: Allow multiple pids

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
    },
    "main": "./cimpler.js",
    "scripts": {
-      "test": "mocha --reporter spec --timeout 4000 --slow 500 test/*"
+      "test": "mocha --reporter spec --timeout 30000 --slow 500 test/*"
    }
 }

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -37,7 +37,10 @@ function buildConsumer(config, cimpler, repoPath) {
          timeout: config.timeout || 0,
          maxBuffer: config.maxBuffer || 1024 * 1024 * 2
       },
-      killChildrenOnExit = "trap '[ $(jobs -p) ] && kill $(jobs -p)' EXIT",
+      killChildrenOnExit = `trap '[ -z "$(jobs -p)" ] || kill -SIGTERM $(jobs -p) \
+         && sleep 2 \ 
+         && [ -z "$(jobs -p)" ] || kill -SIGKILL $(jobs -p); \
+         wait $(jobs -p)' EXIT`,
       cdToRepo = 'set -v; set -x; cd ' + quote(repoPath);
 
       for(var key in process.env) {

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -38,10 +38,15 @@ function buildConsumer(config, cimpler, repoPath) {
          maxBuffer: config.maxBuffer || 1024 * 1024 * 2,
          shell: '/bin/bash'
       },
-      killChildrenOnExit = `trap '[ -z "$(jobs -p)" ] || kill -SIGTERM $(jobs -p) \
-         && sleep 2 \ 
-         && [ -z "$(jobs -p)" ] || kill -SIGKILL $(jobs -p); \
-         wait $(jobs -p)' EXIT`,
+      killChildrenOnExit = `
+         trap '
+            [ -z "$(jobs -p)" ] || kill -SIGTERM $(jobs -p)
+            && sleep 2
+            && [ -z "$(jobs -p)" ] || kill -SIGKILL $(jobs -p)
+            ; wait $(jobs -p)
+         '
+         EXIT`
+      ,
       cdToRepo = 'set -v; set -x; cd ' + quote(repoPath);
 
       for(var key in process.env) {

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -35,7 +35,8 @@ function buildConsumer(config, cimpler, repoPath) {
             BUILD_STATUS: build.status
          },
          timeout: config.timeout || 0,
-         maxBuffer: config.maxBuffer || 1024 * 1024 * 2
+         maxBuffer: config.maxBuffer || 1024 * 1024 * 2,
+         shell: '/bin/bash'
       },
       killChildrenOnExit = `trap '[ -z "$(jobs -p)" ] || kill -SIGTERM $(jobs -p) \
          && sleep 2 \ 


### PR DESCRIPTION
The expression being expanded now has two items rather than the one it had before.
And [ 12312 123123 ] is a syntax error.