### PR TITLE
git-build: use process groups to manage subprocs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
    },
    "main": "./cimpler.js",
    "scripts": {
-      "test": "mocha --reporter spec --timeout 4000 --slow 500 test/*"
+      "test": "mocha --reporter spec --timeout 30000 --slow 500 test/*"
    }
 }

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -37,7 +37,10 @@ function buildConsumer(config, cimpler, repoPath) {
          timeout: config.timeout || 0,
          maxBuffer: config.maxBuffer || 1024 * 1024 * 2
       },
-      killChildrenOnExit = "trap '[ $(jobs -p) ] && kill $(jobs -p)' EXIT",
+      killChildrenOnExit = `trap '[ -z "$(jobs -p)" ] || kill -SIGTERM $(jobs -p) \
+         && sleep 2 \ 
+         && [ -z "$(jobs -p)" ] || kill -SIGKILL $(jobs -p); \
+         wait $(jobs -p)' EXIT`,
       cdToRepo = 'set -v; set -x; cd ' + quote(repoPath);
 
       for(var key in process.env) {

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -294,6 +294,7 @@ function buildConsumer(config, cimpler, repoPath) {
                child.stderr.setEncoding('utf8');
                var stdout = child.stdout.read();
                var stderr = child.stderr.read();
+               clearAbort(build);
                var errObj = code == 0 ? null : {code: code, signal: signal};
                callback(forceErr || errObj, stdout, stderr);
             });
@@ -325,6 +326,13 @@ function setAbort(build, callback) {
       logger.info(id(build) + " -- Build Aborted");
       callback();
    }
+}
+
+function clearAbort(build) {
+   if (!build._control) {
+      build._control = {};
+   }
+   delete build._control.abortGitBuild;
 }
 
 function id(inBuild) {

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -38,10 +38,15 @@ function buildConsumer(config, cimpler, repoPath) {
          maxBuffer: config.maxBuffer || 1024 * 1024 * 2,
          shell: '/bin/bash'
       },
-      killChildrenOnExit = `trap '[ -z "$(jobs -p)" ] || kill -SIGTERM $(jobs -p) \
-         && sleep 2 \ 
-         && [ -z "$(jobs -p)" ] || kill -SIGKILL $(jobs -p); \
-         wait $(jobs -p)' EXIT`,
+      killChildrenOnExit = `
+         trap '
+            [ -z "$(jobs -p)" ] || kill -SIGTERM $(jobs -p)
+            && sleep 2
+            && [ -z "$(jobs -p)" ] || kill -SIGKILL $(jobs -p)
+            ; wait $(jobs -p)
+         '
+         EXIT`
+      ,
       cdToRepo = 'set -v; set -x; cd ' + quote(repoPath);
 
       for(var key in process.env) {

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -35,7 +35,8 @@ function buildConsumer(config, cimpler, repoPath) {
             BUILD_STATUS: build.status
          },
          timeout: config.timeout || 0,
-         maxBuffer: config.maxBuffer || 1024 * 1024 * 2
+         maxBuffer: config.maxBuffer || 1024 * 1024 * 2,
+         shell: '/bin/bash'
       },
       killChildrenOnExit = `trap '[ -z "$(jobs -p)" ] || kill -SIGTERM $(jobs -p) \
          && sleep 2 \ 

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -37,16 +37,8 @@ function buildConsumer(config, cimpler, repoPath) {
          timeout: config.timeout || 0,
          maxBuffer: config.maxBuffer || 1024 * 1024 * 2,
          stdio: 'pipe',
+         detached: true
       },
-      killChildrenOnExit = `
-         trap '
-            [ -z "$(jobs -p)" ] || kill -SIGTERM $(jobs -p)
-            && sleep 2
-            && [ -z "$(jobs -p)" ] || kill -SIGKILL $(jobs -p)
-            ; wait $(jobs -p)
-         '
-         EXIT`
-      ,
       cdToRepo = 'set -v; set -x; cd ' + quote(repoPath);
 
       for(var key in process.env) {
@@ -204,7 +196,7 @@ function buildConsumer(config, cimpler, repoPath) {
          });
 
          setAbort(build, function() {
-            proc.kill('SIGTERM');
+            process.kill(-proc.pid);
             proc.stdout.destroy();
             proc.stderr.destroy();
          });
@@ -281,7 +273,7 @@ function buildConsumer(config, cimpler, repoPath) {
             setTimeout(function() {
                if (done) return;
                forceErr = {signal: "timeout", code: execOptions.timeout};
-               child.kill();
+               process.kill(-child.pid);
             }, options.timeout);
             delete options.timeout;
          }


### PR DESCRIPTION
Now we launch the processes in a new process group and kill
all the sub-procs in that group when we need to abort.
Previously we assumed bash and tried to use TRAP with `jobs -p`
which doesn't include any grandchildren procs.