### PR TITLE
Github Commit Status: allow custom context

### DIFF
--- a/plugins/github-commit-status.js
+++ b/plugins/github-commit-status.js
@@ -30,6 +30,7 @@ exports.init = function(config, cimpler) {
       if (!build.commit) return;
 
       var commitStatus = {
+         context: config.context || 'default',
          user: repo.user,
          repo: repo.name,
          sha: build.commit,

--- a/test/github-commit-status.test.js
+++ b/test/github-commit-status.test.js
@@ -30,6 +30,7 @@ describe("Github commit status plugin", function() {
          assert.equal(statuses.length, 2);
 
          var status = {
+            context: 'test-context',
             user: 'user',
             repo: 'repo',
             sha: build.commit,
@@ -57,6 +58,7 @@ describe("Github commit status plugin", function() {
             assert.equal(statuses.length, 2);
 
             var status = {
+               context: 'test-context',
                user: 'user',
                repo: 'repo',
                sha: build.commit,
@@ -87,6 +89,7 @@ describe("Github commit status plugin", function() {
             assert.equal(statuses.length, 1);
 
             var expectedStatus = {
+               context: 'test-context',
                user: 'user',
                repo: 'repo',
                sha: build.commit,
@@ -111,7 +114,8 @@ function sendBuild(build, callback) {
    GH = newApi();
 
    cimpler.registerPlugin(GCS, {
-      _overrideApi: GH
+      _overrideApi: GH,
+      context: 'test-context',
    });
 
    var statuses = GH.collected.statuses;


### PR DESCRIPTION
Now that github supports multiple statuses per commit,
let's let the user configure the 'context' name instead
of only reporting as 'default'.

Closes #69