### PR TITLE
cli: take a --config=path option

### DIFF
--- a/bin/cimpler
+++ b/bin/cimpler
@@ -3,6 +3,7 @@
 var childProcess = require('child_process'),
 httpTrigger    = require('../lib/http-trigger'),
 Git            = require('../lib/git'),
+ConfigProvider = require('../lib/config-provider'),
 git            = new Git(),
 build          = {},
 args           = require('optimist')
@@ -38,6 +39,8 @@ connectionOptions = {
    httpHost: args.host,
    httpPort: args.port
 };
+
+ConfigProvider.load();
 
 switch (command) {
    case 'build':

--- a/bin/cimpler
+++ b/bin/cimpler
@@ -18,7 +18,7 @@ args           = require('optimist')
       describe: 'Custom shell command to execute for this build instead of the one from the config file'
    })
    .options('config', {
-      describe: 'specify the config file to use'
+      describe: 'specify the config file to use for any command (defaults to {project root}/config.js)'
    })
    .options('branch', {
       alias: 'b',
@@ -30,11 +30,11 @@ args           = require('optimist')
    })
    .options('host', {
       alias: 'h',
-      describe: 'HTTP host of the cimpler server (defaults to the value in config.js)'
+      describe: 'HTTP host of the cimpler server (defaults to the value in config)'
    })
    .options('port', {
       alias: 'p',
-      describe: 'HTTP port of the cimpler server (defaults to the value in config.js)'
+      describe: 'HTTP port of the cimpler server (defaults to the value in config)'
    }).argv;
 
 var command = args._[0];

--- a/bin/cimpler
+++ b/bin/cimpler
@@ -4,17 +4,21 @@ var childProcess = require('child_process'),
 httpTrigger    = require('../lib/http-trigger'),
 Git            = require('../lib/git'),
 ConfigProvider = require('../lib/config-provider'),
+Cimpler        = require('../lib/cimpler'),
 git            = new Git(),
 build          = {},
 args           = require('optimist')
    .demand(1)
    .usage("Examples:\n" +
-   "   cimpler build [-b branch-name]   trigger a build on the current repo\n" +
-   "   cimpler status                   echo the list of builds in the queue (* means building)\n" + 
-   "   cimpler server                   start the cimpler server. Logging to STDOUT.")
+   "   cimpler build [-b branch-name]      trigger a build on the current repo\n" +
+   "   cimpler status                      echo the list of builds in the queue (* means building)\n" +
+   "   cimpler server [--config=path/config.js]  start the cimpler server. Logging to STDOUT.")
    .options('command', {
       alias: 'c',
       describe: 'Custom shell command to execute for this build instead of the one from the config file'
+   })
+   .options('config', {
+      describe: 'specify the config file to use'
    })
    .options('branch', {
       alias: 'b',
@@ -40,7 +44,10 @@ connectionOptions = {
    httpPort: args.port
 };
 
-ConfigProvider.load();
+if (args.config) {
+   var path = require('path');
+   ConfigProvider.load(args.config);
+}
 
 switch (command) {
    case 'build':
@@ -89,7 +96,7 @@ switch (command) {
       });
       break;
    case 'server':
-      require("../server.js");
+      cimpler = new Cimpler(ConfigProvider.get());
       break;
 }
 

--- a/lib/cimpler.js
+++ b/lib/cimpler.js
@@ -99,6 +99,7 @@ function Cimpler(config) {
             .use(Connect.bodyParser())
             .use(Connect.query());
 
+         logger.info('Listening on port: ' + config.httpPort);
          connectServer = connect.listen(config.httpPort);
       }
 

--- a/lib/config-provider.js
+++ b/lib/config-provider.js
@@ -1,6 +1,7 @@
 var path = require('path');
 var fs = require('fs');
 var config;
+var loaded = false;
 
 exports.load = function(configPath) {
    loaded = true;
@@ -9,7 +10,7 @@ exports.load = function(configPath) {
 
 exports.get = function() {
    if (!loaded) {
-      throw new Error("Config file must loaded with '.load()'");
+      throw new Error("Config file must be loaded with '.load()'");
    }
    return config;
 }

--- a/lib/config-provider.js
+++ b/lib/config-provider.js
@@ -1,11 +1,28 @@
 var path = require('path');
+var fs = require('fs');
 var config;
 
 exports.load = function(configPath) {
    loaded = true;
-   return config = require(configPath || path.join(__dirname, "../config.js"));
+   return config = loadConfigFile(configPath);
 }
 
 exports.get = function() {
+   if (!loaded) {
+      throw new Error("Config file must loaded with '.load()'");
+   }
    return config;
+}
+
+function loadConfigFile(configPath) {
+   if (configPath) {
+      return require(configPath);
+   }
+   configPath = path.join(__dirname, "../config.js");
+   try {
+      if (fs.statSync(configPath)) {
+         return require(configPath);
+      }
+   } catch (err) {}
+   return {};
 }

--- a/lib/config-provider.js
+++ b/lib/config-provider.js
@@ -1,0 +1,11 @@
+var path = require('path');
+var config;
+
+exports.load = function(configPath) {
+   loaded = true;
+   return config = require(configPath || path.join(__dirname, "../config.js"));
+}
+
+exports.get = function() {
+   return config;
+}

--- a/lib/http-trigger.js
+++ b/lib/http-trigger.js
@@ -101,6 +101,7 @@ exports.getStatus = function(options, callback) {
          if (res.statusCode != 200) {
             console.log("Error retreiving build status, "+
                         "got http response code: " + res.statusCode);
+            console.log("body: " + body);
             process.exit(1);
          }
 

--- a/lib/http-trigger.js
+++ b/lib/http-trigger.js
@@ -1,20 +1,24 @@
 var http     = require('http'),
     fs       = require('fs'),
     url      = require('url'),
+    ConfigProvider = require('./config-provider');
     connectionTimeout = 30*60*1000, // 30 min
     defaulthttpHost = 'localhost',
     defaulthttpPort = 25750;
+
+    ConfigProvider.load();
 
 /**
  * Provides a function to inject a build into the system using
  * the same http port as the CLI plugin.
  */
 exports.injectBuild = function injectBuild(build, options, callback) {
+   var config = ConfigProvider.get();
    var httpHost = (options && options.httpHost)
-               || loadHostFromConfig()
+               || (config && config.httpHost)
                || defaulthttpHost;
    var httpPort = (options && options.httpPort)
-               || loadPortFromConfig()
+               || (config && config.httpPort)
                || defaulthttpPort;
 
    process.stdout.write("Adding build of " + build.branch + " to the queue ... ");
@@ -65,11 +69,12 @@ exports.injectBuild = function injectBuild(build, options, callback) {
 }
 
 exports.getStatus = function(options, callback) {
+   var config = ConfigProvider.get();
    var httpHost = (options && options.httpHost)
-               || loadHostFromConfig()
+               || (config && config.httpHost)
                || defaulthttpHost;
    var httpPort = (options && options.httpPort)
-               || loadPortFromConfig()
+               || (config && config.httpPort)
                || defaulthttpPort;
 
    var options = {
@@ -106,23 +111,4 @@ exports.getStatus = function(options, callback) {
          process.exit(1);
       });
    }
-}
-
-function loadHostFromConfig() {
-   var config = loadConfig(__dirname + '/../config.js');
-   return config && config.httpHost;
-}
-
-function loadPortFromConfig() {
-   var config = loadConfig(__dirname + '/../config.js');
-   return config && config.httpPort;
-}
-
-function loadConfig(path) {
-   try {
-      if (fs.statSync(path)) {
-         return require(path);
-      }
-   } catch (err) {}
-   return {};
 }

--- a/server.js
+++ b/server.js
@@ -1,4 +1,0 @@
-var Cimpler = require('./lib/cimpler'),
-    config  = require('./config');
-
-cimpler = new Cimpler(config);

--- a/test/builds-status.test.js
+++ b/test/builds-status.test.js
@@ -2,7 +2,8 @@ var Cimpler  = require('../lib/cimpler');
 var http     = require('http');
 var assert   = require('assert');
 var _        = require('underscore');
-var httpPort = 25750;
+var testConfig = require('./test-config.js');
+var httpPort = testConfig.httpPort;
 
 describe("build-status plugin", function() {
    it("should provide build list via http", function(done) {

--- a/test/cimpler.test.js
+++ b/test/cimpler.test.js
@@ -3,7 +3,8 @@ var Cimpler       = require('../lib/cimpler'),
     expect        = require("./expect"),
     assert        = require('assert'),
     http          = require('http'),
-    httpPort      = 25750;
+    testConfig    = require('./test-config.js'),
+    httpPort      = testConfig.httpPort;
 
 describe("Cimpler", function() {
    describe(".registerPlugins()", function() {

--- a/test/cli-plugin.test.js
+++ b/test/cli-plugin.test.js
@@ -3,10 +3,11 @@ var Cimpler  = require('../lib/cimpler'),
     assert   = require('assert'),
     stream   = require('stream'),
     _        = require('underscore'),
-    childProcess = require('child_process');
+    childProcess = require('child_process'),
+    testConfig   = require('./test-config.js'),
+    httpPort     = testConfig.httpPort;
 
 describe("CLI plugin", function() {
-   var httpPort = 25750;
    it("should accept builds via HTTP", function(done) {
       var cb = 0,
       cimpler = createCimpler();

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,8 +1,8 @@
 var Cimpler      = require('../lib/cimpler'),
     fs           = require('fs'),
     path         = require('path'),
-    assert       = require('assert');
-    _            = require('underscore');
+    assert       = require('assert'),
+    _            = require('underscore'),
     expect       = require("./expect"),
     childProcess = require('child_process'),
     testRepoDir  = __dirname + "/../fixtures/repo/",

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -94,7 +94,7 @@ describe("CLI server command", function() {
    var exec = execInDir(testRepoDir);
 
    it("takes in the config option", function(done) {
-      var configPath = testConfigFile(httpPort);
+      var configPath = testConfigFile();
       var proc = exec(bin, ["server", "--config=" + configPath],
       function(output) {
          var pattern = "Listening on port: " + httpPort;
@@ -197,7 +197,7 @@ function execInDir(dir) {
    };
 }
 
-function testConfigFile(port) {
+function testConfigFile() {
    var configPath = path.join(testRepoDir, "./config.temp.js");
    fs.writeFileSync(configPath,
    "module.exports = " + JSON.stringify({

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -90,13 +90,7 @@ describe("CLI server command", function() {
    var exec = execInDir(testRepoDir);
 
    it("takes in the config option", function(done) {
-      var configPath = path.join(testRepoDir, "./config.temp.js");
-      fs.writeFileSync(configPath,
-      "module.exports = " + JSON.stringify({
-         httpHost: 'localhost',
-         httpPort: httpPort,
-         plugins: {cli: true}
-      }));
+      var configPath = testConfig(httpPort);
       var proc = exec("../../bin/cimpler server --config=" + configPath, function(output) {
          var pattern = "Listening on port: " + httpPort;
          assert(output.match(new RegExp(pattern)))
@@ -186,4 +180,15 @@ function execInDir(dir) {
          callback && callback(stdout.toString() + stderr.toString());
       });
    };
+}
+
+function testConfig(port) {
+   var configPath = path.join(testRepoDir, "./config.temp.js");
+   fs.writeFileSync(configPath,
+   "module.exports = " + JSON.stringify({
+      httpHost: 'localhost',
+      httpPort: httpPort,
+      plugins: {cli: true}
+   }));
+   return configPath;
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -8,6 +8,7 @@ var Cimpler      = require('../lib/cimpler'),
     testConfig   = require('./test-config.js'),
     testRepoDir  = testConfig.testRepoDir,
     httpPort     = testConfig.httpPort;
+var bin          = __dirname + "/../bin/cimpler";
 
 describe("CLI build command", function() {
    var exec = execInDir(testRepoDir);
@@ -32,7 +33,6 @@ describe("CLI build command", function() {
          _control: {}
       };
 
-      var bin = "../../bin/cimpler"
       var args = ["-h", "127.0.0.1", "-p", httpPort];
 
       var check = expect(4, function() {
@@ -95,7 +95,7 @@ describe("CLI server command", function() {
 
    it("takes in the config option", function(done) {
       var configPath = testConfigFile(httpPort);
-      var proc = exec(__dirname + "/../bin/cimpler", ["server", "--config=" + configPath],
+      var proc = exec(bin, ["server", "--config=" + configPath],
       function(output) {
          var pattern = "Listening on port: " + httpPort;
          assert(output.match(new RegExp(pattern)));
@@ -120,7 +120,6 @@ describe("CLI status command", function() {
          testMode: true  // Don't console.log() anything
       });
 
-      var bin = __dirname + "/../bin/cimpler";
       var args = ["-h", "127.0.0.1", "-p", httpPort];
 
       cimpler.addBuild({

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,5 +1,6 @@
 var Cimpler      = require('../lib/cimpler'),
     fs           = require('fs'),
+    path         = require('path'),
     assert       = require('assert');
     _            = require('underscore');
     expect       = require("./expect"),
@@ -85,6 +86,28 @@ describe("CLI build command", function() {
    });
 });
 
+describe("CLI server command", function() {
+   var exec = execInDir(testRepoDir);
+
+   it("takes in the config option", function(done) {
+      var configPath = path.join(testRepoDir, "./config.temp.js");
+      var port = 25752;
+      fs.writeFileSync(configPath,
+      "module.exports = " + JSON.stringify({
+         httpHost: 'localhost',
+         httpPort: port,
+         plugins: {cli: true}
+      }));
+      var proc = exec("../../bin/cimpler server --config=" + configPath, function(output) {
+         assert(output.match(/Listening on port: 25752/));
+         done();
+      }, true);
+      setTimeout(function() {
+         proc.kill();
+      }, 1000);
+   });
+});
+
 describe("CLI status command", function() {
    var exec = execInDir("./");
 
@@ -147,7 +170,7 @@ function execInDir(dir) {
       var execOptions = {
          cwd: dir
       };
-      childProcess.exec(cmd, execOptions, function(err, stdout, stderr) {
+      return childProcess.exec(cmd, execOptions, function(err, stdout, stderr) {
          if (!expectFailure && err) {
             console.error("Command failed: " + cmd);
             console.log(stdout.toString());
@@ -159,7 +182,7 @@ function execInDir(dir) {
             console.log(stderr.toString());
             process.exit(1);
          }
-         callback(stdout.toString());
+         callback && callback(stdout.toString() + stderr.toString());
       });
    };
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -91,18 +91,19 @@ describe("CLI server command", function() {
 
    it("takes in the config option", function(done) {
       var configPath = path.join(testRepoDir, "./config.temp.js");
-      var port = 25752;
       fs.writeFileSync(configPath,
       "module.exports = " + JSON.stringify({
          httpHost: 'localhost',
-         httpPort: port,
+         httpPort: httpPort,
          plugins: {cli: true}
       }));
       var proc = exec("../../bin/cimpler server --config=" + configPath, function(output) {
-         assert(output.match(/Listening on port: 25752/));
+         var pattern = "Listening on port: " + httpPort;
+         assert(output.match(new RegExp(pattern)))
          done();
+         clearInterval(killerInterval);
       }, true);
-      setTimeout(function() {
+      var killerInterval = setInterval(function() {
          proc.kill();
       }, 1000);
    });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -5,8 +5,9 @@ var Cimpler      = require('../lib/cimpler'),
     _            = require('underscore'),
     expect       = require("./expect"),
     childProcess = require('child_process'),
-    testRepoDir  = __dirname + "/../fixtures/repo/",
-    httpPort     = 25750;
+    testConfig   = require('./test-config.js'),
+    testRepoDir  = testConfig.testRepoDir,
+    httpPort     = testConfig.httpPort;
 
 describe("CLI build command", function() {
    var exec = execInDir(testRepoDir);
@@ -90,7 +91,7 @@ describe("CLI server command", function() {
    var exec = execInDir(testRepoDir);
 
    it("takes in the config option", function(done) {
-      var configPath = testConfig(httpPort);
+      var configPath = testConfigFile(httpPort);
       var proc = exec("../../bin/cimpler server --config=" + configPath, function(output) {
          var pattern = "Listening on port: " + httpPort;
          assert(output.match(new RegExp(pattern)))
@@ -182,7 +183,7 @@ function execInDir(dir) {
    };
 }
 
-function testConfig(port) {
+function testConfigFile(port) {
    var configPath = path.join(testRepoDir, "./config.temp.js");
    fs.writeFileSync(configPath,
    "module.exports = " + JSON.stringify({

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -4,7 +4,8 @@ var Cimpler  = require('../lib/cimpler'),
     assert   = require('assert'),
     expect   = require("./expect"),
     _        = require('underscore'),
-    httpPort = 25750;
+    testConfig = require('./test-config.js'),
+    httpPort = testConfig.httpPort;
 
 var config = {a: 1},
 commit = "sha1232322",

--- a/test/post-recieve.test.js
+++ b/test/post-recieve.test.js
@@ -1,13 +1,14 @@
 var Cimpler      = require('../lib/cimpler'),
     util         = require('util'),
     fs           = require('fs'),
-    assert       = require('assert');
+    assert       = require('assert'),
     expect       = require("./expect"),
     childProcess = require('child_process'),
     path         = require('path'),
     _            = require('underscore'),
-    testRepoDir  = path.normalize(__dirname + "/../fixtures/repo/"),
-    httpPort     = 25750;
+    testConfig   = require('./test-config.js'),
+    testRepoDir  = testConfig.testRepoDir,
+    httpPort     = testConfig.httpPort;
 
 describe("post-receive git-hook", function() {
    it("should trigger a build when passed info via stdin", function(done) {

--- a/test/test-config.js
+++ b/test/test-config.js
@@ -1,6 +1,6 @@
 var path = require('path');
 
 module.exports = {
-   httpPort: 25750,
+   httpPort: 25751,
    testRepoDir: path.normalize(__dirname + "/../fixtures/repo/"),
 };

--- a/test/test-config.js
+++ b/test/test-config.js
@@ -1,0 +1,6 @@
+var path = require('path');
+
+module.exports = {
+   httpPort: 25750,
+   testRepoDir: path.normalize(__dirname + "/../fixtures/repo/"),
+};


### PR DESCRIPTION
Instead of just assuming the config file will always be at
`./config.js`, take a CLI arg `--config=`... so we can talk to different
cimpler servers / launch multiple cimplers with one install.

Closes #89