### PR TITLE
Clean build directory after checkout and merge

### DIFF
--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -137,6 +137,7 @@ function buildConsumer(config, cimpler, repoPath) {
             "git submodule foreach --recursive git clean -ffd && " +
             "git checkout "+ quote(build.commit) + " && " +
             "git merge " + quote("origin/" + branchToMerge) + " && " +
+            "git clean -ffd && " +
             "git submodule sync && " +
             "git submodule update --init --recursive ) 2>&1";
 


### PR DESCRIPTION
This ensures we clean files that are ignored in the branch we're coming from but aren't ignored in our new branch.

The old behavior caused problems when moving the location of a `node_modules` directory, which was ignored on each branch in the place that branch expects it. So we could have a situation where we have
```
master:.gitignore
	/old/node_modules

branch:.gitignore
	/node_modules
```
and when an `/old/node_modules` directory exists, it will not be deleted on checkout of `branch` (because it's ignored by `master`, which is still checked out at the point where we do the `git clean`). Worse still, when we go from `branch` back to another pull on `master` we leave the `/node_modules` directory behind. Potentially this breaks an unrelated branch, and there's not a good way to avoid it without this pull.