### PR TITLE
git-build: don't fail on cleaning failure

### DIFF
--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -134,7 +134,7 @@ function buildConsumer(config, cimpler, repoPath) {
          var commands = '(' + cdToRepo + " && " +
             "git reset --hard && " +
             "git clean -ffd && " +
-            "git submodule foreach --recursive git clean -ffd && " +
+            "(git submodule foreach --recursive git clean -ffd || true) && " +
             "git checkout "+ quote(build.commit) + " && " +
             "git merge " + quote("origin/" + branchToMerge) + " && " +
             "git clean -ffd && " +


### PR DESCRIPTION
Previously, if a branch had a submodule but no entry in .gitmodules, it
would leave the CI directory in an unrecoverable state. The next branch
to come along would try `git submodule foreach` and git would complain
that there's no entry in .gitmodules.

This *clean before switching branches* thing was meant to help when
submodules had untracked files left behind, so I think it's worth
keeping.