### PR TITLE
git-build: allow main branch to be configured

### DIFF
--- a/config.sample.js
+++ b/config.sample.js
@@ -109,6 +109,12 @@ module.exports = {
           */
          mergeBranchRegexes: [],
          /**
+          * The branch that each pull request is merged into before running CI.
+          * Typically 'main', 'master', 'development', ...
+          * Defaults to 'master'.
+          */
+         mainBranch: 'main',
+         /**
           * The shell command that is run for each build.
           * The exit code of this command determines success or failure
           * of the build. Both stdout and stderr are sent to the log.

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -119,7 +119,7 @@ function buildConsumer(config, cimpler, repoPath) {
       }
 
       function startMerge() {
-         var branchToMerge = 'master';
+         var branchToMerge = config.mainBranch || 'master';
          var regex, mergeBranch;
          if (config.mergeBranchRegexes) {
             for (var i = 0; i < config.mergeBranchRegexes.length; ++i) {


### PR DESCRIPTION
So we can handle repos who's main branch is something other than master.

References: danielbeardsley/cimpler#78