### PR TITLE
Cimpler: record build.queuedAt timestamp

### DIFF
--- a/lib/cimpler.js
+++ b/lib/cimpler.js
@@ -23,6 +23,7 @@ function Cimpler(config) {
 
    this.addBuild = function(build) {
       build.status = build.status || 'pending';
+      build.queuedAt = cimpler.getTimestamp();
 
       // The _control property allows plugins to pass around data
       // without clobbering real build properties.
@@ -34,6 +35,9 @@ function Cimpler(config) {
        config.shouldMergeBuilds : buildEquals;
       for (var i = 0; i < existingBuilds.length; i++) {
          if (shouldMergeBuilds(existingBuilds[i], build)) {
+            // Retain the time this was added to the queue when merging
+            // builds
+            build.queuedAt = existingBuilds[i].queuedAt;
             existingBuilds[i] = build;
             return;
          }
@@ -44,6 +48,9 @@ function Cimpler(config) {
       var runningConsumer = this.isBuildRunning(build);
       if (config.abortMatchingBuilds && runningConsumer) {
          builds.items().unshift(build);
+         // Retain the time this was added to the queue when aborting
+         // a similar build.
+         build.queuedAt = runningConsumer.build.queuedAt;
          this.emit('buildAborted', runningConsumer.build);
       } else {
          builds.push(build);
@@ -178,6 +185,8 @@ function Cimpler(config) {
       var plugin = require(pluginPath);
       cimpler.registerPlugin(plugin, pluginConfig);
    });
+
+   this.getTimestamp = Date.now;
 }
 util.inherits(Cimpler, events.EventEmitter);
 

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -32,7 +32,8 @@ function buildConsumer(config, cimpler, repoPath) {
             BUILD_REPO:   build.repo,
             BUILD_COMMIT: build.commit,
             BUILD_BRANCH: build.branch,
-            BUILD_STATUS: build.status
+            BUILD_STATUS: build.status,
+            BUILD_QUEUED_AT: build.queuedAt,
          },
          timeout: config.timeout || 0,
          maxBuffer: config.maxBuffer || 1024 * 1024 * 2,
@@ -55,9 +56,10 @@ function buildConsumer(config, cimpler, repoPath) {
 
       // This needs to be delayed until we have a commit hash
       function writeLogHeader() {
+         const queueTimeMin = Math.round((Date.now() - build.queuedAt) / 1000*60);
          logFile().write( 
             "----------------------------------------------\n" +
-            " Cimpler build started at: " + Date() + "\n" +
+            " Cimpler build started at: " + Date() + " time in queue: " + queueTimeMin + "min \n" +
             "----------------------------------------------\n");
       }
 

--- a/plugins/shell.js
+++ b/plugins/shell.js
@@ -7,7 +7,8 @@ exports.init = function(config, cimpler) {
             BUILD_REPO:   build.repo,
             BUILD_COMMIT: build.commit,
             BUILD_BRANCH: build.branch,
-            BUILD_STATUS: build.status
+            BUILD_STATUS: build.status,
+            BUILD_QUEUED_AT: build.queuedAt,
          }
       };
       childProcess.exec(config.cmd, options, function(err) {

--- a/test/cli-plugin.test.js
+++ b/test/cli-plugin.test.js
@@ -22,7 +22,7 @@ describe("CLI plugin", function() {
       cimpler.consumeBuild(function(inBuild) {
          cimpler.shutdown();
 
-         var sanitizedBuild = _.omit(inBuild, '_control');
+         var sanitizedBuild = _.omit(inBuild, '_control', 'queuedAt');
          assert.deepEqual(sanitizedBuild, build);
          done();
       });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -45,7 +45,7 @@ describe("CLI build command", function() {
          started();
 
          builtBranches.push(inBuild.branch);
-         assert.deepEqual(inBuild, expectedBuild);
+         assert.deepEqual(_.omit(inBuild, 'queuedAt'), expectedBuild);
          // So the next assertion will succeed
          expectedBuild.branch = 'test-branch';
          expectedBuild.buildCommand = 'blah';

--- a/test/git-build.test.js
+++ b/test/git-build.test.js
@@ -198,6 +198,35 @@ describe("git-build plugin", function() {
       });
    });
 
+   it("should expose the BUILD_QUEUED_AT env var", function(done) {
+      var cimpler = new Cimpler({
+         plugins: {
+            "git-build": {
+               repoPaths: testRepoDirs[0],
+               cmd: '[ "$BUILD_QUEUED_AT" = "1234" ]',
+            }
+         },
+      });
+
+      function finished() {
+         cimpler.shutdown();
+         done();
+      }
+
+      cimpler.on('buildFinished', function(build) {
+         assert.equal(build.status, 'success');
+         assert.equal(1234, build.queuedAt);
+         finished();
+      });
+
+      cimpler.getTimestamp = () => 1234;
+      cimpler.addBuild({
+         letter: 'A',
+         repo: "doesn't matter",
+         branch: "omg/a/slash",
+      });
+   });
+
    it("should perform build logging correctly", function(done) {
       var cimpler = new Cimpler({
          plugins: {


### PR DESCRIPTION
Also, expose that in an ENV var in the git build plugin.

Some tests needed a bit of adjusting to deal with this.

It's useful to know how long a build has been queued.