### PR TITLE
Add option to set build timeout with build argument

### DIFF
--- a/bin/cimpler
+++ b/bin/cimpler
@@ -39,6 +39,10 @@ args           = require('optimist')
    .options('port', {
       alias: 'p',
       describe: 'HTTP port of the cimpler server (defaults to the value in config)'
+   })
+   .options('timeout', {
+      alias: 't',
+      describe: 'Specify the timeout of the build (in milliseconds)'
    }).argv;
 
 var command = args._[0];
@@ -57,6 +61,9 @@ switch (command) {
    case 'build':
       if (args.command) {
          build.buildCommand = args.command;
+      }
+      if (args.timeout) {
+         build.buildTimeout = args.timeout;
       }
       git.remote(function(remote, repoPath) {
          if (remote && remote.indexOf('github.com') !== -1) {

--- a/bin/cimpler
+++ b/bin/cimpler
@@ -42,7 +42,7 @@ args           = require('optimist')
    })
    .options('timeout', {
       alias: 't',
-      describe: 'Specify the timeout of the build (in milliseconds)'
+      describe: 'Specify the timeout for builds (in milliseconds)'
    }).argv;
 
 var command = args._[0];
@@ -117,4 +117,3 @@ switch (command) {
       cimpler = new Cimpler(ConfigProvider.get());
       break;
 }
-

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -35,7 +35,7 @@ function buildConsumer(config, cimpler, repoPath) {
             BUILD_STATUS: build.status,
             BUILD_QUEUED_AT: build.queuedAt,
          },
-         timeout: config.timeout || 0,
+         timeout: process.env.buildTimeout || config.timeout || 0,
          maxBuffer: config.maxBuffer || 1024 * 1024 * 2,
          stdio: 'pipe',
          detached: true

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -184,7 +184,7 @@ function buildConsumer(config, cimpler, repoPath) {
                build.code = err ? err.code : 0;
             }
             logger.info(id(build) + " -- Build " + build.status);
-            finishedBuild();
+            setTimeout(finishedBuild, 0);
          });
 
          /**

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -35,7 +35,7 @@ function buildConsumer(config, cimpler, repoPath) {
             BUILD_STATUS: build.status,
             BUILD_QUEUED_AT: build.queuedAt,
          },
-         timeout: process.env.buildTimeout || config.timeout || 0,
+         timeout: build.buildTimeout || config.timeout || 0,
          maxBuffer: config.maxBuffer || 1024 * 1024 * 2,
          stdio: 'pipe',
          detached: true

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -109,6 +109,33 @@ describe("CLI server command", function() {
    });
 });
 
+describe("CLI build timeout", function() {
+   var exec = execInDir(testRepoDir);
+
+   it("sets the build timeout", function(done) {
+      var cimpler = new Cimpler({
+         plugins: {
+            cli: {
+            }
+         },
+         httpPort: httpPort,
+         testMode: true  // Don't console.log() anything
+      });
+      var timeout = 1 * 1000; // 1 second timeout
+      cimpler.on('buildFinished', function(build) {
+         assert.equal(build.buildTimeout, timeout);
+      });
+      var args = ["-h", "127.0.0.1", "-p", httpPort];
+      var proc = exec(bin,  args.concat(["build", '--timeout=' + timeout]));
+      cimpler.consumeBuild(function(inBuild, started, finished) {
+         started();
+         finished();
+         cimpler.shutdown();
+         done();
+      });
+   });
+});
+
 describe("CLI status command", function() {
    var exec = execInDir("./");
 

--- a/test/git-build.test.js
+++ b/test/git-build.test.js
@@ -374,6 +374,49 @@ describe("git-build plugin", function() {
          });
       });
 
+      it.only("should be overriden by build.buildTimeout", function(done) {
+         const seconds = 4;
+         const timeoutSeconds = 0.1;
+         let start;
+
+         var cimpler = new Cimpler({
+            plugins: {
+               "git-build": {
+                  // This timeout should be overridden by the buildTimeout
+                  timeout: seconds * 2,
+                  repoPaths: testRepoDirs[0],
+                  // command that will take longer than timeout
+                  cmd: "sleep " + seconds,
+                  logs: {
+                     path: buildLogsPath,
+                     url:  "http://www.example.com/ci-builds/"
+                  },
+               }
+            },
+         });
+
+         function finished() {
+            cimpler.shutdown();
+            done();
+         }
+
+         cimpler.on('buildFinished', function(build) {
+            assert.equal(build.status, 'error');
+            if (Date.now() - start > seconds * 1000) {
+               assert.fail("Build should have timed out before the sleep command finished");
+            }
+            finished();
+         });
+
+         start = Date.now();
+         cimpler.addBuild({
+            letter: 'A',
+            repo: "doesn't matter",
+            branch: "master",
+            buildTimeout: timeoutSeconds * 1000
+         });
+      });
+
       it("should abort a build when told to", function(done) {
          var cimpler = new Cimpler({
             abortMatchingBuilds: true,

--- a/test/git-build.test.js
+++ b/test/git-build.test.js
@@ -374,7 +374,7 @@ describe("git-build plugin", function() {
          });
       });
 
-      it.only("should be overriden by build.buildTimeout", function(done) {
+      it("should be overriden by build.buildTimeout", function(done) {
          const seconds = 4;
          const timeoutSeconds = 0.1;
          let start;


### PR DESCRIPTION
Coverage takes more than our default timeout of two hours which is set in 
the cimpler config. Add the ability to set the build timeout using a build
command argument.

Related: https://github.com/iFixit/ifixit/pull/35075

@danielbeardsley @BaseInfinity 