### PR TITLE
git-build: commit merge without running hooks

### DIFF
--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -138,7 +138,7 @@ function buildConsumer(config, cimpler, repoPath) {
             "git clean -ffd && " +
             "(git submodule foreach --recursive git clean -ffd || true) && " +
             "git checkout "+ quote(build.commit) + " && " +
-            "git merge " + quote("origin/" + branchToMerge) + " && " +
+            "git merge --no-verify " + quote("origin/" + branchToMerge) + " && " +
             "git clean -ffd && " +
             "git submodule sync && " +
             "git submodule update --init --recursive ) 2>&1";


### PR DESCRIPTION
We want cimpler to be able to merge in master regardless of if
the repo's git hooks are set up correctly. Otherwise, if a built branch
sets up bad hooks, it can prevent further builds from even merging
in master.