### PR TITLE
git-build: Add html output support

### DIFF
--- a/config.sample.js
+++ b/config.sample.js
@@ -130,7 +130,12 @@ module.exports = {
             // Base Url to access the above log files.
             url:  "http://www.example.com/ci-builds/"
          },
-         enabled: true
+         enabled: true,
+         /**
+          * Surrounds all cimpler output in formatted html tags
+          */
+         printHtml: true
+
       }/** , {
          * Any plugin who's configuration object is an array
          * will have it's .init() function called once for each element

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -40,7 +40,7 @@ function buildConsumer(config, cimpler, repoPath) {
          stdio: 'pipe',
          detached: true
       },
-      cdToRepo = 'set -v; set -x; cd ' + quote(repoPath);
+      cdToRepo = 'set -v; cd ' + quote(repoPath);
 
       for(var key in process.env) {
          execOptions.env[key] = process.env[key];

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -57,10 +57,13 @@ function buildConsumer(config, cimpler, repoPath) {
       // This needs to be delayed until we have a commit hash
       function writeLogHeader() {
          const queueTimeMin = Math.round((Date.now() - build.queuedAt) / (1000*60));
-         logFile().write( 
+
+         var startedMessage =
             "----------------------------------------------\n" +
             " Cimpler build started at: " + Date() + " time in queue: " + queueTimeMin + "min \n" +
-            "----------------------------------------------\n");
+            "----------------------------------------------\n";
+
+         logBuildStarted(startedMessage);
       }
 
       /**
@@ -215,6 +218,26 @@ function buildConsumer(config, cimpler, repoPath) {
          return inBuild.logPath;
       }
 
+      function logBuildStarted(text) {
+         if (config.printHtml) {
+            logFile().write('<pre>');
+         }
+         logFile().write(text);
+
+      }
+
+      function logBuildFinished(text) {
+         logFile().write(text);
+
+         if (config.printHtml) {
+            logFile().write('</pre>');
+         }
+         // Call 'finished' when end() flushes it's data to disk
+         // This is mostly for testing so we *known* that the data has been
+         // written.
+         logFile().end('', 'utf8', finished);
+      }
+
       var logFileStream;
       function logFile() {
          if (logFileStream) {
@@ -238,19 +261,18 @@ function buildConsumer(config, cimpler, repoPath) {
          }
 
          var seconds = Math.round((Date.now() - startedAt) / 1000);
-         logFile().write(
+         var finishedMessage =
           "\n-------------------------------------------" +
-          "\n Cimpler build finished in " + seconds + " seconds");
+          "\n Cimpler build finished in " + seconds + " seconds";
          if (build.error) {
-            logFile().write("\n Error: " + build.error);
+            finishedMessage += "\n Error: " + build.error;
          } else {
-            logFile().write("\n Status: " + build.status + " Exit Code: " + build.code);
+            finishedMessage += "\n Status: " + build.status + " Exit Code: " + build.code;
          }
-         // Call 'finished' when end() flushes it's data to disk
-         // This is mostly for testing so we *known* that the data has been
-         // written.
-         logFile().end(
-          "\n-------------------------------------------\n",'utf8',finished);
+         finishedMessage +=
+          "\n-------------------------------------------\n";
+
+         logBuildFinished(finishedMessage);
       }
 
       function exec(cmd, callback) {

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -108,7 +108,7 @@ function buildConsumer(config, cimpler, repoPath) {
                stdout += "\n\n" + failed;
                logger.warn(id(build) + " -- " + failed);
                writeLogHeader()
-               logFile().write(stdout);
+               writeLogFile(stdout);
                finishedBuild();
             } else {
                if (!build.commit) {
@@ -166,7 +166,7 @@ function buildConsumer(config, cimpler, repoPath) {
 
 
             logger.info(id(build) + " -- " + message);
-            logFile().write(stdout);
+            writeLogFile(stdout);
 
             nextStep(started);
          });
@@ -219,23 +219,30 @@ function buildConsumer(config, cimpler, repoPath) {
       }
 
       function logBuildStarted(text) {
-         if (config.printHtml) {
-            logFile().write('<pre>');
-         }
-         logFile().write(text);
-
+         writeLogFile(text);
       }
 
       function logBuildFinished(text) {
+         writeLogFile(text, /* end */ true);
+      }
+
+      function writeLogFile(text, end = false) {
+         if (config.printHtml) {
+            logFile().write('<pre>');
+         }
+
          logFile().write(text);
 
          if (config.printHtml) {
             logFile().write('</pre>');
          }
-         // Call 'finished' when end() flushes it's data to disk
-         // This is mostly for testing so we *known* that the data has been
-         // written.
-         logFile().end('', 'utf8', finished);
+
+         if (end) {
+            // Call 'finished' when end() flushes it's data to disk
+            // This is mostly for testing so we *known* that the data has been
+            // written.
+            logFile().end('', 'utf8', finished);
+         }
       }
 
       var logFileStream;


### PR DESCRIPTION
If we pass in a `printHtml` config option, we surround the text
with `<pre>...</pre>` tags which signify preformatted text.

It's simple and should get the job done.

Also, updated the sample config.

Closes https://github.com/danielbeardsley/cimpler/issues/108