### PR TITLE
git-build: Add option to not merge in main branch/master

### DIFF
--- a/config.sample.js
+++ b/config.sample.js
@@ -134,7 +134,11 @@ module.exports = {
          /**
           * Surrounds all cimpler output in formatted html tags
           */
-         printHtml: true
+         printHtml: true,
+         /**
+          * Do not merge in the main branch
+          */
+         noMerge: true,
 
       }/** , {
          * Any plugin who's configuration object is an array

--- a/config.sample.js
+++ b/config.sample.js
@@ -111,6 +111,7 @@ module.exports = {
          /**
           * The branch that each pull request is merged into before running CI.
           * Typically 'main', 'master', 'development', ...
+          * Setting as null will not merge in any branch.
           * Defaults to 'master'.
           */
          mainBranch: 'main',
@@ -135,10 +136,6 @@ module.exports = {
           * Surrounds all cimpler output in formatted html tags
           */
          printHtml: true,
-         /**
-          * Do not merge in the main branch
-          */
-         noMerge: true,
 
       }/** , {
          * Any plugin who's configuration object is an array

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -140,8 +140,8 @@ function buildConsumer(config, cimpler, repoPath) {
             "git reset --hard && " +
             "git clean -ffd && " +
             "(git submodule foreach --recursive git clean -ffd || true) && " +
-            "git checkout "+ quote(build.commit) + " && " +
-            "git merge --no-verify " + quote("origin/" + branchToMerge) + " && " +
+            "git checkout " + quote(build.commit) + " && " +
+            (config.noMerge ? '' : ("git merge --no-verify " + quote("origin/" + branchToMerge) + " && ")) +
             "git clean -ffd && " +
             "git submodule sync && " +
             "git submodule update --init --recursive ) 2>&1";

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -124,9 +124,10 @@ function buildConsumer(config, cimpler, repoPath) {
       }
 
       function startMerge() {
+         let shouldMerge = config.mainBranch !== null;
          var branchToMerge = config.mainBranch || 'master';
          var regex, mergeBranch;
-         if (config.mergeBranchRegexes) {
+         if (shouldMerge && config.mergeBranchRegexes) {
             for (var i = 0; i < config.mergeBranchRegexes.length; ++i) {
                regex = config.mergeBranchRegexes[i][0];
                mergeBranch = config.mergeBranchRegexes[i][1];
@@ -141,7 +142,7 @@ function buildConsumer(config, cimpler, repoPath) {
             "git clean -ffd && " +
             "(git submodule foreach --recursive git clean -ffd || true) && " +
             "git checkout " + quote(build.commit) + " && " +
-            (config.noMerge ? '' : ("git merge --no-verify " + quote("origin/" + branchToMerge) + " && ")) +
+            (shouldMerge ? ("git merge --no-verify " + quote("origin/" + branchToMerge) + " && ") : '') +
             "git clean -ffd && " +
             "git submodule sync && " +
             "git submodule update --init --recursive ) 2>&1";


### PR DESCRIPTION
Our coverage cimpler can't have master merged in because CodeCov
compares the coverage to the base commit of the branch. If we merged
in master, we could get many unrelated changes that would affect
our coverage numbers.

This allows us to configure cimpler to not merge in master.