### PR TITLE
Add PR number to build

### DIFF
--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -34,6 +34,7 @@ function buildConsumer(config, cimpler, repoPath) {
             BUILD_BRANCH: build.branch,
             BUILD_STATUS: build.status,
             BUILD_QUEUED_AT: build.queuedAt,
+            BUILD_NUMBER: build.number,
          },
          timeout: build.buildTimeout || config.timeout || 0,
          maxBuffer: config.maxBuffer || 1024 * 1024 * 2,

--- a/plugins/github.js
+++ b/plugins/github.js
@@ -58,7 +58,8 @@ function extractPushBuildInfo(payload) {
      repo   : "github.com" + '/' + payload.repository.full_name,
      commit : payload.after,
      branch : branch,
-     status : 'pending'
+     status : 'pending',
+     number : null
    };
 }
 
@@ -74,11 +75,13 @@ function extractPullRequestBuildInfo(payload) {
    const branch = headCommit.ref;
    const commit = headCommit.sha;
    const status = 'pending';
+   const number = payload.number;
 
    return {
       repo   : "github.com" + '/' + repoName,
       commit : commit,
       branch : branch,
-      status : status
+      status : status,
+      number : number
    };
 }

--- a/plugins/shell.js
+++ b/plugins/shell.js
@@ -9,6 +9,7 @@ exports.init = function(config, cimpler) {
             BUILD_BRANCH: build.branch,
             BUILD_STATUS: build.status,
             BUILD_QUEUED_AT: build.queuedAt,
+            BUILD_NUMBER: build.number,
          }
       };
       childProcess.exec(config.cmd, options, function(err) {

--- a/test/git-build.test.js
+++ b/test/git-build.test.js
@@ -232,7 +232,7 @@ describe("git-build plugin", function() {
          plugins: {
             "git-build": {
                repoPaths: testRepoDirs[0],
-               cmd: 'echo hello',
+               cmd: '[ $BUILD_NUMBER = 1234 ]',
             }
          },
       });
@@ -261,7 +261,7 @@ describe("git-build plugin", function() {
          plugins: {
             "git-build": {
                repoPaths: testRepoDirs[0],
-               cmd: 'echo hello',
+               cmd: '[ $BUILD_NUMBER = null ]',
             }
          },
       });

--- a/test/git-build.test.js
+++ b/test/git-build.test.js
@@ -273,7 +273,7 @@ describe("git-build plugin", function() {
 
       cimpler.on('buildFinished', function(build) {
          assert.equal(build.status, 'success');
-         assert.equal(null, build.number);
+         assert.strictEqual(null, build.number);
          finished();
       });
 

--- a/test/git-build.test.js
+++ b/test/git-build.test.js
@@ -227,6 +227,64 @@ describe("git-build plugin", function() {
       });
    });
 
+   it("should expose the BUILD_NUMBER env var", function(done) {
+      var cimpler = new Cimpler({
+         plugins: {
+            "git-build": {
+               repoPaths: testRepoDirs[0],
+               cmd: 'echo hello',
+            }
+         },
+      });
+
+      function finished() {
+         cimpler.shutdown();
+         done();
+      }
+
+      cimpler.on('buildFinished', function(build) {
+         assert.equal(build.status, 'success');
+         assert.equal(1234, build.number);
+         finished();
+      });
+
+      cimpler.addBuild({
+         letter: 'A',
+         repo: "doesn't matter",
+         branch: "omg/a/slash",
+         number: '1234',
+      });
+   });
+
+   it("should allow a null BUILD_NUMBER", function(done) {
+      var cimpler = new Cimpler({
+         plugins: {
+            "git-build": {
+               repoPaths: testRepoDirs[0],
+               cmd: 'echo hello',
+            }
+         },
+      });
+
+      function finished() {
+         cimpler.shutdown();
+         done();
+      }
+
+      cimpler.on('buildFinished', function(build) {
+         assert.equal(build.status, 'success');
+         assert.equal(null, build.number);
+         finished();
+      });
+
+      cimpler.addBuild({
+         letter: 'A',
+         repo: "doesn't matter",
+         branch: "omg/a/slash",
+         number: null,
+      });
+   });
+
    it("should perform build logging correctly", function(done) {
       var cimpler = new Cimpler({
          plugins: {

--- a/test/shell.test.js
+++ b/test/shell.test.js
@@ -24,7 +24,8 @@ describe("Shell plugin", function() {
             'BUILD_REPO',
             'BUILD_COMMIT',
             'BUILD_BRANCH',
-            'BUILD_STATUS'],
+            'BUILD_STATUS',
+            'BUILD_NUMBER'],
          cimpler = new Cimpler();
 
          // Load the shell plugin with a cmd that writes the env vars to a file
@@ -36,7 +37,8 @@ describe("Shell plugin", function() {
             repo:'repo',
             commit: '12345',
             branch: 'master',
-            status: 'began'
+            status: 'began',
+            number: '999'
          });
 
          cimpler.on('buildFinished',
@@ -51,7 +53,8 @@ describe("Shell plugin", function() {
                   build.repo,
                   build.commit,
                   build.branch,
-                  'began' // build.status (status will have changed)
+                  'began', // build.status (status will have changed)
+                  build.number
                ].join(' ');
 
                assert.equal(contents, expectedContents + "\n");


### PR DESCRIPTION
We now send out an env var of the PR number. This is required for Coveralls because we
need to set the `CI_PULL_REQUEST` variable.

Also, added some tests. I thought this would have broke tests in a few other places but
that didn't seem to be the case.

CC @danielbeardsley @BaseInfinity 