### PR TITLE
Update octokit package to newest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 6
   - 8
   - 10
   - 12

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ property like: `function(config, cimpler)`
 
 ## Requirements
 
- * [Node.js](http://nodejs.org/) (0.6 and above)
+ * [Node.js](http://nodejs.org/) (8 and above)
 
 ## Inspired By
 

--- a/config.sample.js
+++ b/config.sample.js
@@ -30,16 +30,14 @@ module.exports = {
          /**
           * For updating commit status via the github API
           *
-          * Passed straight through to github.authenticate()
-          * from the `github` npm module:
-          * https://github.com/ajaxorg/node-github
-          * So it accepts whatever that function accpets.
+          * Passed straight through to Octokit
+          * from the `@octokit/rest` npm module,
+          * so it accepts whatever that function accepts.
           *
           * Get an oauth token by going to https://github.com/settings/tokens
-          * and createa token with only repo:status permission
+          * and create a token with only repo:status permission.
           */
          auth: {
-            type: 'oauth', // or 'basic'
             token: 'abcdefghijklmnopqrs...'
          }
       },

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
       "url": "https://github.com/danielbeardsley/cimpler.git"
    },
    "dependencies": {
+      "@octokit/rest": "^18.5.6",
       "connect": "~2.6.0",
-      "github": "~3.1.1",
       "log4js": "~0.5.4",
       "notify-queue": "~0.0.5",
       "optimist": "~0.3.4",

--- a/plugins/github-commit-status.js
+++ b/plugins/github-commit-status.js
@@ -1,10 +1,10 @@
 var util   = require('util'),
-Git        = require('../lib/git'),
-GitHubApi  = require('@octokit/rest');
+Git        = require('../lib/git');
+let { Octokit } = require('@octokit/rest');
 
 exports.init = function(config, cimpler) {
    // Just to allow mocking the api in the tests.
-   GitHubApi = config._overrideApi || GitHubApi;
+   Octokit = config._overrideApi || Octokit;
 
    var GitHub = getGithubApi(config);
 
@@ -32,22 +32,21 @@ exports.init = function(config, cimpler) {
 
       var commitStatus = {
          context: config.context || 'default',
-         user: repo.user,
+         owner: repo.user,
          repo: repo.name,
          sha: build.commit,
          state: status,
          target_url: build.logUrl,
          description: description };
-      GitHub.repos.createStatus(commitStatus);
+      GitHub.repos.createCommitStatus(commitStatus);
    }
 };
 
 function getGithubApi(config) {
-   var githubApi = new GitHubApi({
+   return new Octokit({
       headers: {
          "user-agent": "Cimpler CI"
-      }
+      },
+      auth: config.auth.token
    });
-   githubApi.authenticate(config.auth);
-   return githubApi;
 }

--- a/plugins/github-commit-status.js
+++ b/plugins/github-commit-status.js
@@ -1,6 +1,6 @@
 var util   = require('util'),
 Git        = require('../lib/git'),
-GitHubApi  = require('github');
+GitHubApi  = require('@octokit/rest');
 
 exports.init = function(config, cimpler) {
    // Just to allow mocking the api in the tests.

--- a/test/github-commit-status.test.js
+++ b/test/github-commit-status.test.js
@@ -3,21 +3,6 @@ var Cimpler  = require('../lib/cimpler'),
     assert   = require('assert');
 
 describe("Github commit status plugin", function() {
-   describe("authentication", function() {
-      it("should pass the 'auth' config object straight through", function() {
-         var auth = {a: 1},
-         cimpler = new Cimpler(),
-         GH = newApi();
-
-         cimpler.registerPlugin(GCS, {
-            auth: auth,
-            _overrideApi: GH
-         });
-
-         assert.equal(GH.collected.auth, auth);
-      });
-   });
-
    it("started then finished", function(done) {
       var build = {
          repo: "git://github.com/user/repo.git",
@@ -31,7 +16,7 @@ describe("Github commit status plugin", function() {
 
          var status = {
             context: 'test-context',
-            user: 'user',
+            owner: 'user',
             repo: 'repo',
             sha: build.commit,
             state: 'pending',
@@ -59,7 +44,7 @@ describe("Github commit status plugin", function() {
 
             var status = {
                context: 'test-context',
-               user: 'user',
+               owner: 'user',
                repo: 'repo',
                sha: build.commit,
                state: 'pending',
@@ -90,7 +75,7 @@ describe("Github commit status plugin", function() {
 
             var expectedStatus = {
                context: 'test-context',
-               user: 'user',
+               owner: 'user',
                repo: 'repo',
                sha: build.commit,
                state: 'error',
@@ -114,6 +99,7 @@ function sendBuild(build, callback) {
    GH = newApi();
 
    cimpler.registerPlugin(GCS, {
+      auth: {token: 1},
       _overrideApi: GH,
       context: 'test-context',
    });
@@ -151,13 +137,9 @@ function newApi() {
 
    function ghAPI() {
       this.repos = {
-         createStatus: function(status) {
+         createCommitStatus: function(status) {
             info.statuses.push(status);
          }
-      };
-
-      this.authenticate = function(auth) {
-         info.auth = auth;
       };
    }
 


### PR DESCRIPTION
The newest version of OctoKit works with GitHub's new authentication requirements (see [GitHub's blog post](https://github.blog/changelog/2021-04-19-sunsetting-api-authentication-via-query-parameters-and-the-oauth-applications-api/)).

This requires us to remove support for Node 6.