### PR TITLE
git-build: soak up data from child proc

### DIFF
--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -77,14 +77,16 @@ function buildConsumer(config, cimpler, repoPath) {
          var next = startFetch;
          if (shouldPrune()) {
             var command = 'cd ' + quote(repoPath) + ' && ' + "git prune 2>&1";
-            exec(command, function(err, stdout) {
+            exec(command, function(err, output) {
                if (err) {
                   var failed = "git prune failed";
                   build.status = 'error';
                   build.error = failed;
                   build.code = err.code;
-                  stdout += "\n\n" + failed;
+                  output += "\n\n" + failed;
                   logger.warn(id(build) + " -- " + failed);
+                  writeLogHeader();
+                  writeLogFile(output);
                   finishedBuild();
                } else {
                   next();

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -179,7 +179,7 @@ function buildConsumer(config, cimpler, repoPath) {
          var commands = [cdToRepo, buildCommand];
          var commandString = commands.join("; ");
 
-         var proc = exec(commandString, function(err, stdout, stderr) {
+         var proc = exec(commandString, function(err) {
             if (err && err.signal) {
                build.status = 'error';
                build.error = err.signal + " - " + err.code;

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -288,6 +288,7 @@ function buildConsumer(config, cimpler, repoPath) {
 
       function exec(cmd, callback) {
          var child, done = false, forceErr, options = _.clone(execOptions);
+         var output = [];
          if (options.timeout) {
             setTimeout(function() {
                if (done) return;
@@ -301,14 +302,15 @@ function buildConsumer(config, cimpler, repoPath) {
          child = childProcess.spawn('bash', args, execOptions)
          .on('exit', function(code, signal) {
             done = true;
-            child.stdout.setEncoding('utf8');
-            child.stderr.setEncoding('utf8');
-            var stdout = child.stdout.read();
-            var stderr = child.stderr.read();
             setAbort(build, function () {});
             var errObj = code == 0 ? null : {code: code, signal: signal};
-            callback(forceErr || errObj, stdout, stderr);
+            callback(forceErr || errObj, output.join(""));
          });
+
+         child.stdout.setEncoding('utf8');
+         child.stderr.setEncoding('utf8');
+         child.stdout.on('data', function(out) { output.push(out); });
+         child.stderr.on('data', function(out) { output.push(out); });
 
          setAbort(build, function() {
             process.kill(-child.pid);

--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -296,17 +296,17 @@ function buildConsumer(config, cimpler, repoPath) {
          }
 
          var args = ['-c', cmd];
-         child = childProcess.spawn('bash', args, execOptions).on('exit',
-            function(code, signal) {
-               done = true;
-               child.stdout.setEncoding('utf8');
-               child.stderr.setEncoding('utf8');
-               var stdout = child.stdout.read();
-               var stderr = child.stderr.read();
-               setAbort(build, function () {});
-               var errObj = code == 0 ? null : {code: code, signal: signal};
-               callback(forceErr || errObj, stdout, stderr);
-            });
+         child = childProcess.spawn('bash', args, execOptions)
+         .on('exit', function(code, signal) {
+            done = true;
+            child.stdout.setEncoding('utf8');
+            child.stderr.setEncoding('utf8');
+            var stdout = child.stdout.read();
+            var stderr = child.stderr.read();
+            setAbort(build, function () {});
+            var errObj = code == 0 ? null : {code: code, signal: signal};
+            callback(forceErr || errObj, stdout, stderr);
+         });
 
          setAbort(build, function() {
             process.kill(-child.pid);


### PR DESCRIPTION
Previously, we were only reading at the end, this would lock up the
process (preventing exit) if it produced more than {buffer size} of data.

Now we do the traditional data event listening and join them all at the
end. Note: we only do this when asked to, see individual commits for more info.

cr_req 1

Closes danielbeardsley/cimpler#121